### PR TITLE
feat: Rename o4-mini server to openai with multi-model support

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -8,7 +8,7 @@ This file provides guidance to Claude Code (claude.ai/code) when working with co
 - **Format code**: `deno task fmt`
 - **Check formatting**: `deno task fmt:check`
 - **Lint code**: `deno task lint`
-- **Run server**: `deno run --allow-read --allow-net --allow-env servers/o4-mini.ts`
+- **Run server**: `deno run --allow-read --allow-net --allow-env servers/openai.ts`
 - **Run tests**: `deno test --allow-env servers/gemini.ts`
 
 ### Git Hooks
@@ -37,12 +37,12 @@ The architecture uses a type-safe pattern for defining and implementing MCP tool
 
 ### Server Implementation Pattern
 
-Servers follow this pattern (see `servers/o4-mini.ts` and `servers/gemini.ts`):
+Servers follow this pattern (see `servers/openai.ts` and `servers/gemini.ts`):
 
 1. Define tools as const arrays satisfying the `Tool` type
 2. Use `createToolsServer()` with server info, tools array, and handler map
 3. Connect using appropriate transport (typically `StdioServerTransport`)
-4. Environment variables control server behavior (e.g., `SEARCH_CONTEXT_SIZE`, `REASONING_EFFORT`, `GEMINI_API_KEY`)
+4. Environment variables control server behavior (e.g., `OPENAI_MODEL`, `SEARCH_CONTEXT_SIZE`, `REASONING_EFFORT`, `GEMINI_API_KEY`)
 
 ### Key Dependencies
 

--- a/README.md
+++ b/README.md
@@ -15,12 +15,12 @@ AI-powered web search using OpenAI models.
 
 **Environment Variables:**
 - `OPENAI_API_KEY` (required): Your OpenAI API key
-- `OPENAI_MODEL` (optional): OpenAI model to use (default: `o4-mini`)
-- `SEARCH_CONTEXT_SIZE` (optional): Controls search context size - `low`, `medium`, or `high` (default: `high`)
-- `REASONING_EFFORT` (optional): Controls reasoning effort - `low`, `medium`, or `high` (default: `high`)
+- `OPENAI_MODEL` (optional): OpenAI model to use (default: `o3`)
+- `SEARCH_CONTEXT_SIZE` (optional): Controls search context size - `low`, `medium`, or `high` (default: `medium`)
+- `REASONING_EFFORT` (optional): Controls reasoning effort - `low`, `medium`, or `high` (default: `medium`)
 
 **Available Tools:**
-- `o4-mini-search`: An AI agent with advanced web search capabilities. Useful for finding latest information and troubleshooting errors. Supports natural language queries.
+- `openai-search`: An AI agent with advanced web search capabilities. Useful for finding latest information and troubleshooting errors. Supports natural language queries.
   - Input: `query` (string) - Ask questions, search for information, or consult about complex problems in English
   - Output: The search result as a string
 

--- a/README.md
+++ b/README.md
@@ -9,12 +9,13 @@ Personal MCP (Model Context Protocol) servers implemented in TypeScript/Deno.
 
 ## Available Servers
 
-### o4-mini
+### openai
 
-AI-powered web search using OpenAI's o4-mini model.
+AI-powered web search using OpenAI models.
 
 **Environment Variables:**
 - `OPENAI_API_KEY` (required): Your OpenAI API key
+- `OPENAI_MODEL` (optional): OpenAI model to use (default: `o4-mini`)
 - `SEARCH_CONTEXT_SIZE` (optional): Controls search context size - `low`, `medium`, or `high` (default: `high`)
 - `REASONING_EFFORT` (optional): Controls reasoning effort - `low`, `medium`, or `high` (default: `high`)
 
@@ -25,7 +26,7 @@ AI-powered web search using OpenAI's o4-mini model.
 
 ```bash
 # Run directly (has shebang and executable permissions)
-./servers/o4-mini.ts
+./servers/openai.ts
 ```
 
 ### gemini
@@ -66,4 +67,4 @@ deno task lint     # Lint code
 
 ## Creating New Servers
 
-See `servers/o4-mini.ts` and `servers/gemini.ts` for examples. Use `lib/tools-server.ts` to create type-safe MCP servers with Zod validation.
+See `servers/openai.ts` and `servers/gemini.ts` for examples. Use `lib/tools-server.ts` to create type-safe MCP servers with Zod validation.

--- a/README.md
+++ b/README.md
@@ -16,6 +16,7 @@ AI-powered web search using OpenAI models.
 **Environment Variables:**
 - `OPENAI_API_KEY` (required): Your OpenAI API key
 - `OPENAI_MODEL` (optional): OpenAI model to use (default: `o3`)
+- `OPENAI_MAX_TOKENS` (optional): Maximum number of tokens for the response
 - `SEARCH_CONTEXT_SIZE` (optional): Controls search context size - `low`, `medium`, or `high` (default: `medium`)
 - `REASONING_EFFORT` (optional): Controls reasoning effort - `low`, `medium`, or `high` (default: `medium`)
 

--- a/servers/openai.ts
+++ b/servers/openai.ts
@@ -8,13 +8,13 @@ import { createToolsServer } from "../lib/tools-server.ts";
 import { Tool } from "../lib/type.ts";
 
 const SERVER_NAME = "openai";
-const TOOL_NAME = "o4-mini-search";
+const TOOL_NAME = "openai-search";
 
-const searchContextSize = (Deno.env.get("SEARCH_CONTEXT_SIZE") ?? "high") as
+const searchContextSize = (Deno.env.get("SEARCH_CONTEXT_SIZE") ?? "medium") as
   | "low"
   | "medium"
   | "high";
-const reasoningEffort = (Deno.env.get("REASONING_EFFORT") ?? "high") as
+const reasoningEffort = (Deno.env.get("REASONING_EFFORT") ?? "medium") as
   | "low"
   | "medium"
   | "high";
@@ -46,7 +46,8 @@ const server = createToolsServer(
   {
     async [TOOL_NAME](params: { query: string }) {
       const { text } = await generateText({
-        model: openai.responses(Deno.env.get("OPENAI_MODEL") ?? "o4-mini"),
+        model: openai.responses(Deno.env.get("OPENAI_MODEL") ?? "o3"),
+        experimental_continueSteps: true,
         messages: [
           {
             role: "user",

--- a/servers/openai.ts
+++ b/servers/openai.ts
@@ -7,7 +7,7 @@ import { z } from "zod";
 import { createToolsServer } from "../lib/tools-server.ts";
 import { Tool } from "../lib/type.ts";
 
-const SERVER_NAME = "o4-mini";
+const SERVER_NAME = "openai";
 const TOOL_NAME = "o4-mini-search";
 
 const searchContextSize = (Deno.env.get("SEARCH_CONTEXT_SIZE") ?? "high") as
@@ -27,7 +27,7 @@ const tools = [
   {
     name: TOOL_NAME,
     description:
-      "An AI agent with advanced web search capabilities. Useful for finding latest information and troubleshooting errors. Supports natural language queries.",
+      "An AI agent with advanced web search capabilities using OpenAI models. Useful for finding latest information and troubleshooting errors. Supports natural language queries.",
     inputSchema: {
       query: z.string().describe(
         "Ask questions, search for information, or consult about complex problems in English.",
@@ -46,7 +46,7 @@ const server = createToolsServer(
   {
     async [TOOL_NAME](params: { query: string }) {
       const { text } = await generateText({
-        model: openai.responses("o4-mini"),
+        model: openai.responses(Deno.env.get("OPENAI_MODEL") ?? "o4-mini"),
         messages: [
           {
             role: "user",

--- a/servers/openai.ts
+++ b/servers/openai.ts
@@ -19,6 +19,10 @@ const reasoningEffort = (Deno.env.get("REASONING_EFFORT") ?? "medium") as
   | "medium"
   | "high";
 
+const maxTokens = Deno.env.get("OPENAI_MAX_TOKENS")
+  ? parseInt(Deno.env.get("OPENAI_MAX_TOKENS")!)
+  : undefined;
+
 const openai = createOpenAI({
   apiKey: Deno.env.get("OPENAI_API_KEY") ?? "",
 });
@@ -48,6 +52,7 @@ const server = createToolsServer(
       const { text } = await generateText({
         model: openai.responses(Deno.env.get("OPENAI_MODEL") ?? "o3"),
         experimental_continueSteps: true,
+        maxTokens,
         messages: [
           {
             role: "user",


### PR DESCRIPTION
## Summary
This PR renames the o4-mini server to a more generic openai server and adds support for multiple OpenAI models through configuration. It introduces new environment variables for better flexibility and updates default settings.

## Changes
- Renamed `servers/o4-mini.ts` to `servers/openai.ts` and updated all references
- Added `OPENAI_MODEL` environment variable to select OpenAI models (defaults to `o3`)
- Added `OPENAI_MAX_TOKENS` environment variable for configurable response token limits
- Changed default `searchContextSize` and `reasoningEffort` from `high` to `medium`
- Updated tool name from `o4-mini-search` to `openai-search`
- Added `experimental_continueSteps` for improved multi-step reasoning

## Motivation
The previous implementation was hardcoded to use the o4-mini model. As OpenAI releases new models, users need flexibility to choose which model to use without modifying the code. This change makes the server more versatile and future-proof.

## Technical Details
The implementation uses environment variables to configure model selection and token limits, allowing users to easily switch between different OpenAI models. The server now supports any OpenAI model available through the API, with o3 as the new default.

## Impact
- Affected features: OpenAI-powered web search functionality
- Modified files: `servers/openai.ts` (renamed from `servers/o4-mini.ts`), `README.md`, `CLAUDE.md`
- Breaking changes: Yes - tool name changed from `o4-mini-search` to `openai-search`

## Testing
1. Set `OPENAI_API_KEY` environment variable
2. Run the server: `./servers/openai.ts`
3. Test with different models by setting `OPENAI_MODEL` (e.g., `o3`, `o4-mini`, `gpt-4-turbo`)
4. Verify token limits work by setting `OPENAI_MAX_TOKENS`

## Checklist
- [ ] Code has been tested and works as expected
- [ ] Tests have been added/updated appropriately
- [x] Documentation has been updated (if necessary)
- [x] Linter and formatter have been run
- [x] Breaking changes have been clearly marked

## Additional Notes
Users currently using `o4-mini-search` tool will need to update their configurations to use `openai-search` instead. The default model has been changed from `o4-mini` to `o3` for improved performance.