### PR TITLE
feat: add timeout and cancellation support for MCP tools

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,0 +1,42 @@
+# Repository Guidelines
+
+## Project Structure & Module Organization
+- `servers/`: TypeScript MCP servers (e.g., `servers/openai.ts`, `servers/gemini.ts`). Tests live alongside as `*.test.ts`.
+- `lib/`: Shared utilities — env validation (`env.ts`), tools server factory (`tools-server.ts`), shared types (`type.ts`).
+- Config: `biome.json`, `bunfig.toml` (tests root `./servers`), `tsconfig.json`, `commitlint.config.cjs`, `lefthook.yml`, `.editorconfig`.
+
+## Build, Test, and Development Commands
+- Install deps: `bun install`
+- Lint/format: `bun run check`
+- Auto-fix lint: `bun run check:fix`
+- Type check: `bun run typecheck`
+- Run tests: `bun run test` (or `bun test`)
+- Run servers:
+  - OpenAI: `bun run servers/openai.ts` (or `./servers/openai.ts`)
+  - Gemini: `bun run servers/gemini.ts` (or `./servers/gemini.ts`)
+
+## Coding Style & Naming Conventions
+- Indentation: 2 spaces for TS/JS; JSON/YAML 2 (see `.editorconfig`).
+- Quotes & width: double quotes, line width 120 (`biome.json`).
+- Modules: ESM (`"type": "module"`). Prefer Zod for schemas and strong typing.
+- Files: kebab-case; tests named `<name>.test.ts` colocated with sources.
+
+## Testing Guidelines
+- Framework: `bun:test`; test root is `./servers`.
+- Place tests as `*.test.ts` next to the target module.
+- Focus on tool I/O validation, env parsing, and error paths.
+- Run with `bun run test` and ensure deterministic output.
+
+## Commit & Pull Request Guidelines
+- Conventional Commits enforced by commitlint (e.g., `feat: add gemini-cli tool`).
+- Hooks: pre-commit runs Biome format/lint; commit-msg validates via commitlint (`lefthook.yml`).
+- PRs: include summary, rationale, affected servers, example commands/output, and linked issues. All checks (`check`, `typecheck`, `test`) must pass.
+
+## Security & Configuration Tips
+- Secrets in `.env` (ignored). Required: `OPENAI_API_KEY`. For Gemini: `GEMINI_API_KEY` or `GOOGLE_GENAI_USE_VERTEXAI=true` with `GOOGLE_CLOUD_PROJECT` (and optional `GOOGLE_CLOUD_LOCATION`).
+- `lib/env.ts` validates and exits on invalid configurations.
+
+## Adding a New Server
+- Create `servers/<name>.ts` with a shebang, define `tools` (name, description, Zod input/output), and build with `createToolsServer(...)`. Connect via Stdio only when `import.meta.main`.
+- Add `servers/<name>.test.ts` using `bun:test` to cover behavior and edge cases.
+

--- a/lib/env.ts
+++ b/lib/env.ts
@@ -13,12 +13,22 @@ const schema = z.object({
   GOOGLE_CLOUD_PROJECT: nonEmpty.optional(),
   GOOGLE_CLOUD_LOCATION: nonEmpty.default("us-central1"),
   GEMINI_API_KEY: nonEmpty.optional(),
+  GEMINI_MCP_TIMEOUT: z.coerce
+    .number()
+    .int()
+    .positive()
+    .default(10 * 60 * 1000), // 10 minutes
 
   SEARCH_CONTEXT_SIZE: z.enum(["low", "medium", "high"]).default("high"),
   REASONING_EFFORT: z.enum(["low", "medium", "high"]).default("high"),
   TEXT_VERBOSITY: z.enum(["low", "medium", "high"]).default("high"),
   OPENAI_API_KEY: nonEmpty,
   OPENAI_MAX_TOKENS: z.coerce.number().int().positive().optional(),
+  OPENAI_MCP_TIMEOUT: z.coerce
+    .number()
+    .int()
+    .positive()
+    .default(10 * 60 * 1000), // 10 minutes
 });
 
 type Env = z.infer<typeof schema>;

--- a/lib/tools-server.ts
+++ b/lib/tools-server.ts
@@ -5,20 +5,69 @@ import type { HandlerMap, Tool } from "./type";
 
 type ServerInfo = Pick<Implementation, "name" | "version">;
 
-export function createToolsServer<T extends Tool[]>(serverInfo: ServerInfo, tools: T, handlers: HandlerMap<T>) {
+export type TimeoutConfig<T extends Tool[]> = {
+  /** Default timeout for all tools in milliseconds */
+  defaultTimeout?: number;
+  /** Per-tool timeouts in milliseconds */
+  perToolTimeout?: Record<T[number]["name"], number>;
+};
+
+export function createToolsServer<T extends Tool[]>(
+  serverInfo: ServerInfo,
+  tools: T,
+  handlers: HandlerMap<T>,
+  timeoutConfig?: TimeoutConfig<T>,
+) {
   const server = new McpServer(serverInfo);
 
   for (const tool of tools) {
+    const name = tool.name as T[number]["name"];
+
     server.registerTool(
-      tool.name,
+      name,
       {
-        title: tool.name,
+        title: name,
         description: tool.description,
         inputSchema: tool.inputSchema,
       },
       async (args) => {
-        const handler = handlers[tool.name as T[number]["name"]];
-        const result = await handler(args as z.infer<z.ZodObject<T[number]["inputSchema"]>>);
+        const handler = handlers[name];
+
+        // Determine the timeout for this tool
+        const timeout = timeoutConfig?.perToolTimeout?.[name] ?? timeoutConfig?.defaultTimeout;
+
+        let result: unknown;
+
+        if (timeout !== undefined) {
+          // Setup optional cancellation and a cleanup-able timer
+          const controller = new AbortController();
+          let timer: ReturnType<typeof setTimeout> | undefined;
+
+          const timeoutPromise = new Promise<never>((_, reject) => {
+            timer = setTimeout(() => {
+              controller.abort();
+              reject(new Error(`Tool '${tool.name}' execution timed out after ${timeout}ms`));
+            }, timeout);
+          });
+
+          try {
+            // Race between the handler and the timeout
+            result = await Promise.race([
+              Promise.resolve(
+                handler(args as z.infer<z.ZodObject<T[number]["inputSchema"]>>, { signal: controller.signal }),
+              ),
+              timeoutPromise,
+            ]);
+          } finally {
+            if (timer !== undefined) {
+              clearTimeout(timer);
+            }
+          }
+        } else {
+          // No timeout configured, execute normally
+          result = await handler(args as z.infer<z.ZodObject<T[number]["inputSchema"]>>);
+        }
+
         const validatedResult = tool.outputSchema.parse(result);
         return {
           content: [{ type: "text", text: JSON.stringify(validatedResult) }],

--- a/lib/type.ts
+++ b/lib/type.ts
@@ -6,9 +6,15 @@ export type Tool = Required<Pick<_Tool, "name" | "description">> & {
   outputSchema: z.ZodType;
 };
 
+export type ToolContext = {
+  /** Abort signal that is triggered when a tool times out */
+  signal?: AbortSignal;
+};
+
 export type HandlerMap<T extends Tool[]> = {
   [K in T[number]["name"]]: (
     params: z.infer<z.ZodObject<Extract<T[number], { name: K }>["inputSchema"]>>,
+    context?: ToolContext,
   ) =>
     | z.infer<Extract<T[number], { name: K }>["outputSchema"]>
     | Promise<z.infer<Extract<T[number], { name: K }>["outputSchema"]>>;


### PR DESCRIPTION
## Summary
This PR implements comprehensive timeout and cancellation support for MCP tools across the framework. It adds configurable timeouts with proper AbortSignal propagation to prevent long-running operations from hanging indefinitely.

## Changes
- Add environment variables `GEMINI_MCP_TIMEOUT` and `OPENAI_MCP_TIMEOUT` with 10-minute defaults
- Implement timeout infrastructure in `createToolsServer()` with per-tool and default timeout configuration
- Add `ToolContext` type with optional `AbortSignal` for cancellation support
- Update OpenAI and Gemini servers to propagate timeout signals to AI SDK calls
- Refactor Gemini CLI tool from Bun shell (`$`) to `Bun.spawn()` for proper signal handling
- Add comprehensive development guidelines and project structure documentation

## Motivation
Long-running MCP tools can cause client timeouts and poor user experience. This implementation provides a robust foundation for timeout management while maintaining backward compatibility.

## Technical Details
The timeout system uses Promise.race() with AbortController for clean cancellation. When configured, tools receive an optional AbortSignal through ToolContext, which is propagated to underlying operations like AI SDK calls and subprocess spawning.

## Impact
- Affected features: All MCP tools now support configurable timeouts
- Affected files: Core framework (`lib/`), both server implementations (`servers/`)
- Breaking changes: No - timeout support is optional and backward compatible

## Testing
1. Run `bun run check` to verify code formatting and linting
2. Run `bun run typecheck` to verify TypeScript compilation
3. Run `bun run test` to execute all tests
4. Test server startup: `bun run servers/openai.ts` and `bun run servers/gemini.ts`

## Checklist
- [x] Code works as expected
- [x] Tests have been added/updated
- [x] Documentation has been updated (if necessary)
- [x] Linter and formatter have been run
- [x] Breaking changes are clearly documented

## Additional Notes
The timeout configuration is environment-driven and defaults to 10 minutes, providing reasonable defaults while allowing customization for different deployment scenarios.