### PR TITLE
chore(renovate): use more specific matching properties for zod package

### DIFF
--- a/.github/renovate.json
+++ b/.github/renovate.json
@@ -29,8 +29,8 @@
       "separateMajorMinor": false
     },
     {
-      "matchManagers": ["bun"],
-      "matchPackageNames": ["zod"],
+      "matchDatasources": ["npm"],
+      "matchDepNames": ["zod"],
       "matchUpdateTypes": ["major"],
       "prCreation": "status-success"
     }


### PR DESCRIPTION
## Summary
Updates Renovate configuration to use more specific matching properties for the zod package. This change replaces the deprecated `matchManagers` and `matchPackageNames` properties with the preferred `matchDatasources` and `matchDepNames` properties.

## Changes
- Updated `.github/renovate.json` to use `matchDatasources: ["npm"]` instead of `matchManagers: ["bun"]`
- Updated `.github/renovate.json` to use `matchDepNames: ["zod"]` instead of `matchPackageNames: ["zod"]`

## Motivation
The current configuration uses deprecated properties that may not work as expected in newer versions of Renovate. Using the more specific `matchDatasources` and `matchDepNames` properties provides better control over package matching and aligns with Renovate's current best practices.

## Technical Details
This is a configuration-only change that improves the precision of Renovate's package matching for zod major updates. The new properties are more explicit about matching npm packages specifically rather than relying on the build manager type.

## Impact
- Affected features: Renovate configuration for zod package updates
- Affected files: `.github/renovate.json`
- Breaking changes: No

## Testing
1. Verify that Renovate configuration is valid
2. Monitor that future zod major version updates are handled correctly
3. Confirm that the `prCreation: "status-success"` behavior is maintained

## Checklist
- [x] Code works as expected
- [x] Tests have been added/updated (N/A for configuration)
- [x] Documentation has been updated (N/A)
- [x] Linter and formatter have been run
- [x] Breaking changes are clearly documented (none)

## Additional Notes
This change maintains the same functional behavior while using the recommended property names for better compatibility with current and future Renovate versions.